### PR TITLE
Fix sourcemaps by avoiding requiring whole waffle

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -857,14 +857,12 @@
     "@types/chai": {
       "version": "4.2.15",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.15.tgz",
-      "integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ==",
-      "dev": true
+      "integrity": "sha512-rYff6FI+ZTKAPkJUoyz7Udq3GaoDZnxYDEvdEdFZASiA7PoErltHezDishqQiSDWrGxvxmplH304jyzQmjp0AQ=="
     },
     "@types/chai-as-promised": {
       "version": "7.1.3",
       "resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz",
       "integrity": "sha512-FQnh1ohPXJELpKhzjuDkPLR2BZCAqed+a6xV4MI/T3XzHfd2FlarfUGUdZYgqYe8oxkYn0fchHEeHfHqdZ96sg==",
-      "dev": true,
       "requires": {
         "@types/chai": "*"
       }
@@ -7759,6 +7757,16 @@
             "extsprintf": "1.3.0",
             "json-schema": "0.2.3",
             "verror": "1.10.0"
+          }
+        },
+        "keccak": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.1.tgz",
+          "integrity": "sha512-epq90L9jlFWCW7+pQa6JOnKn2Xgl2mtI664seYR6MHskvI9agt7AnDqmAlp9TqU4/caMYbA08Hi5DMZAl5zdkA==",
+          "dev": true,
+          "requires": {
+            "node-addon-api": "^2.0.0",
+            "node-gyp-build": "^4.2.0"
           }
         },
         "keyv": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@types/node": "^14.14.32",
     "chai": "^4.3.3",
     "chai-as-promised": "^7.1.1",
+    "@types/chai-as-promised": "^7.1.3",
     "dotenv": "^8.2.0",
     "ethereum-waffle": "^3.3.0",
     "ethers": "^5.0.31",

--- a/test/counter.ts
+++ b/test/counter.ts
@@ -1,10 +1,9 @@
-import { ethers } from "hardhat";
+import { ethers, waffle } from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
-import { solidity } from "ethereum-waffle";
 import { Counter__factory, Counter } from "../typechain";
 
-chai.use(solidity);
+chai.use(waffle.solidity);
 chai.use(chaiAsPromised);
 const { expect } = chai;
 

--- a/test/counter.ts
+++ b/test/counter.ts
@@ -1,9 +1,8 @@
-import { ethers, waffle } from "hardhat";
+import { ethers} from "hardhat";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
 import { Counter__factory, Counter } from "../typechain";
 
-chai.use(waffle.solidity);
 chai.use(chaiAsPromised);
 const { expect } = chai;
 


### PR DESCRIPTION
Currently, sourcemaps are broken. Related: https://github.com/nomiclabs/hardhat/issues/1336

Configuring chai is not needed because `hardhat-waffle` does it under the hood.